### PR TITLE
NIFI-5214: Refactor RestLookupService.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-web-test-utils/src/main/java/org/apache/nifi/web/util/TestServer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-web-test-utils/src/main/java/org/apache/nifi/web/util/TestServer.java
@@ -135,14 +135,14 @@ public class TestServer {
         jetty.destroy();
     }
 
-    private int getPort() {
+    public int getPort() {
         if (!jetty.isStarted()) {
             throw new IllegalStateException("Jetty server not started");
         }
         return ((ServerConnector) jetty.getConnectors()[0]).getLocalPort();
     }
 
-    private int getSecurePort() {
+    public int getSecurePort() {
         if (!jetty.isStarted()) {
             throw new IllegalStateException("Jetty server not started");
         }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/resources/docs/org.apache.nifi.lookup.RestLookupService/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/resources/docs/org.apache.nifi.lookup.RestLookupService/additionalDetails.html
@@ -21,10 +21,9 @@
 </head>
 <body>
     <h2>General</h2>
-    <p>This lookup service has the following required keys:</p>
+    <p>This lookup service has the following optional lookup coordinate keys:</p>
     <ul>
-        <li>mime.type</li>
-        <li>request.method; valid values:
+        <li>request.method; defaults to 'get', valid values:
             <ul>
                 <li>delete</li>
                 <li>get</li>
@@ -32,9 +31,11 @@
                 <li>put</li>
             </ul>
         </li>
+        <li>body; contains a string representing JSON, XML, etc. to be sent with any
+            of those methods except for "get".</li>
+        <li>mime.type; specifies media type of the request body, required when 'body' is passed.</li>
+        <li>*; any other keys can be configured to pass variables to resolve target URLs. See 'Dynamic URLs' section below.</li>
     </ul>
-    <p>In addition to the required keys, a key "body" can be added which contains a string representing JSON, XML, etc. to be sent with any
-    of those methods except for "get."</p>
     <p>The record reader is used to consume the response of the REST service call and turn it into one or more records. The record path property
     is provided to allow for a lookup path to either a nested record or a single point deep in the REST response. Note: a valid schema must be
     built that encapsulates the REST response accurately in order for this service to work.</p>
@@ -50,5 +51,18 @@
         <li>friend.id => "/example/first_friend"</li>
     </ul>
     <p>Would dynamically produce an endpoint of <em>http://example.com/service/john.smith/friend/12345</em></p>
+
+    <h3>Environment specific URLs</h3>
+
+    <p>If target URL has environment specific part, such as server name and port,
+        then 'Base URL' property can be used to resolve it by an expression language with variable registry.
+        This way, the consistent lookup coordinate keys can be used in different environments.</p>
+    <p>Ex. Base URL: <em>http://${apiServerHostname}:${apiServerPort}</em>, combined with example variable registry:</p>
+    <ul>
+        <li>apiServerHostname => "test.example.com"</li>
+        <li>apiServerPort => "8080"</li>
+    </ul>
+    <p>Ex. URL: <em>/service/${user.name}/friend/${friend.id}</em>, combined with the previous example record paths</p>
+    <p>Would dynamically produce an endpoint of <em>http://test.example.com:8080/service/john.smith/friend/12345</em></p>
 </body>
 </html>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/groovy/org/apache/nifi/lookup/TestRestLookupService.groovy
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/groovy/org/apache/nifi/lookup/TestRestLookupService.groovy
@@ -112,7 +112,6 @@ class TestRestLookupService {
 
         runner.disableControllerService(lookupService)
         runner.setProperty(lookupService, RestLookupService.RECORD_PATH, "/person/sport")
-        runner.setProperty(lookupService, RestLookupService.RECORD_PATH_PROPERTY_NAME, "sport")
         runner.enableControllerService(lookupService)
         runner.assertValid()
 

--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/groovy/org/apache/nifi/lookup/rest/handlers/BasicAuth.groovy
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/groovy/org/apache/nifi/lookup/rest/handlers/BasicAuth.groovy
@@ -36,7 +36,7 @@ class BasicAuth extends AbstractHandler {
         def headers = []
         request.headerNames.each { headers << it }
 
-        if (!authString || authString != "Basic am9obi5zbWl0aDpudWxs") {
+        if (!authString || authString != "Basic am9obi5zbWl0aDp0ZXN0aW5nMTIzNA==") {
             response.status = 401
             response.setHeader("WWW-Authenticate", "Basic realm=\"Jetty\"")
             response.setHeader("response.phrase", "Unauthorized")


### PR DESCRIPTION
Hi @MikeThomsen, while I was finalizing #2723 review process, I found several points those need to be fixed. And also few points to improve. Following list summarizes what I've added based on your commits. Can you check and merge this into your PR? Then, I'd give +1 to #2723.

1. Added 'Base URL' property to address environment specific part of URL.
2. Removed 'Record Path Property Name' property, because the name of
a resulted record field of a record path can be obtained by field name.
3. Lower cased HTTP method name should be used throughout.
4. Added mimeType require check when body is specified.
5. Added debug log to print HTTP response code.
6. Prepare for NIFI-5287.
7. Fixed that mime.type being used regardless of whether body is
specified or not, caused NullPointerException when 'mime.type' is not
specified when it is not required.
8. Updated documentation.
9. Updated test to use 'Base URL' property to handle dynamic Jetty port number. And fixed Base64 string causing basic auth test case failure.

Thanks!