### PR TITLE
Refactored the way to evaluate EL for URL property

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/RestLookupService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/RestLookupService.java
@@ -34,9 +34,8 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnDisabled;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
-import org.apache.nifi.attribute.expression.language.PreparedQuery;
-import org.apache.nifi.attribute.expression.language.Query;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
@@ -83,24 +82,12 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
             "as the header name and the value as the header value.")
 })
 public class RestLookupService extends AbstractControllerService implements RecordLookupService {
-    static final PropertyDescriptor BASE_URL = new PropertyDescriptor.Builder()
-        .name("rest-lookup-base-url")
-        .displayName("Base URL")
-        .description("The base URL for the REST endpoint. Expression language is evaluated against variable registry." +
-                " This property can be used to resolve environment specific part of the URL." +
-                " The result string is prepended to the 'URL'." +
-                " See 'Additional Details' to see an example.")
-        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
-        .required(false)
-        .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-        .build();
-
     static final PropertyDescriptor URL = new PropertyDescriptor.Builder()
         .name("rest-lookup-url")
         .displayName("URL")
         .description("The URL for the REST endpoint. Expression language is evaluated against the lookup key/value pairs, " +
-                "not flowfile attributes or variable registry.")
-        .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+                "not flowfile attributes.")
+        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .required(true)
         .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
         .build();
@@ -175,7 +162,6 @@ public class RestLookupService extends AbstractControllerService implements Reco
 
     static {
         DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
-            BASE_URL,
             URL,
             RECORD_READER,
             RECORD_PATH,
@@ -197,7 +183,7 @@ public class RestLookupService extends AbstractControllerService implements Reco
     private RecordPath recordPath;
     private OkHttpClient client;
     private Map<String, String> headers;
-    private volatile PreparedQuery compiledQuery;
+    private volatile PropertyValue urlTemplate;
     private volatile String basicUser;
     private volatile String basicPass;
     private volatile boolean isDigest;
@@ -231,15 +217,12 @@ public class RestLookupService extends AbstractControllerService implements Reco
 
         getHeaders(context);
 
-        final String url = context.getProperty(URL).getValue();
-        compiledQuery = context.getProperty(BASE_URL).isSet()
-                ? Query.prepare(context.getProperty(BASE_URL).evaluateAttributeExpressions().getValue() + url)
-                : Query.prepare(url);
+        urlTemplate = context.getProperty(URL);
     }
 
     @OnDisabled
     public void onDisabled() {
-        this.compiledQuery = null;
+        this.urlTemplate = null;
     }
 
     private void getHeaders(ConfigurationContext context) {
@@ -339,7 +322,7 @@ public class RestLookupService extends AbstractControllerService implements Reco
                 e -> e.getKey(),
                 e -> e.getValue().toString()
             ));
-        return compiledQuery.evaluateExpressions(converted, null);
+        return urlTemplate.evaluateAttributeExpressions(converted).getValue();
     }
 
     protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {

--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/resources/docs/org.apache.nifi.lookup.RestLookupService/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/resources/docs/org.apache.nifi.lookup.RestLookupService/additionalDetails.html
@@ -43,26 +43,23 @@
     <p>Headers are supported using dynamic properties. Just add a dynamic property and the name will be the header name and the value will be the value for the header. Expression language
     powered by input from the variable registry is supported.</p>
     <h2>Dynamic URLs</h2>
-    <p>The URL property supports expression language through the lookup key/value pairs configured on the processor. The configuration specified by the user will be passed
-    through to the expression language engine for evaluation. Note: flowfile attributes and variable registry settings will be disregarded here for this property.</p>
-    <p>Ex. URL: <em>http://example.com/service/${user.name}/friend/${friend.id}</em>, combined with example record paths:</p>
+    <p>The URL property supports expression language through the lookup key/value pairs configured on the component using this lookup service (e.g. LookupRecord processor). The configuration specified by the user will be passed
+    through to the expression language engine for evaluation. Note: flowfile attributes will be disregarded here for this property.</p>
+    <p>Ex. URL: <em>http://example.com/service/${user.name}/friend/${friend.id}</em>, combined with example record paths at LookupRecord processor:</p>
     <ul>
         <li>user.name => "/example/username"</li>
         <li>friend.id => "/example/first_friend"</li>
     </ul>
     <p>Would dynamically produce an endpoint of <em>http://example.com/service/john.smith/friend/12345</em></p>
 
-    <h3>Environment specific URLs</h3>
+    <h3>Using Variable Registry with URLs</h3>
 
-    <p>If target URL has environment specific part, such as server name and port,
-        then 'Base URL' property can be used to resolve it by an expression language with variable registry.
-        This way, the consistent lookup coordinate keys can be used in different environments.</p>
-    <p>Ex. Base URL: <em>http://${apiServerHostname}:${apiServerPort}</em>, combined with example variable registry:</p>
+    <p>In addition to the lookup key/value pairs, Variable Registry can be referred from expression languages configured at the URL property.</p>
+    <p>Ex. URL: <em>http://${apiServerHostname}:${apiServerPort}/service/${user.name}/friend/${friend.id}</em>, combined with the previous example record paths, and variable registry:</p>
     <ul>
         <li>apiServerHostname => "test.example.com"</li>
         <li>apiServerPort => "8080"</li>
     </ul>
-    <p>Ex. URL: <em>/service/${user.name}/friend/${friend.id}</em>, combined with the previous example record paths</p>
     <p>Would dynamically produce an endpoint of <em>http://test.example.com:8080/service/john.smith/friend/12345</em></p>
 </body>
 </html>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/groovy/org/apache/nifi/lookup/RestLookupServiceIT.groovy
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/groovy/org/apache/nifi/lookup/RestLookupServiceIT.groovy
@@ -72,7 +72,6 @@ class RestLookupServiceIT {
         runner.setProperty(reader, SchemaAccessUtils.SCHEMA_REGISTRY, "registry")
         runner.setProperty(lookupService, SchemaAccessUtils.SCHEMA_REGISTRY, "registry")
         runner.setProperty(lookupService, RestLookupService.RECORD_READER, "jsonReader")
-        runner.setProperty(lookupService, RestLookupService.BASE_URL, 'http://localhost:${serverPort}')
         runner.setProperty(TestRestLookupServiceProcessor.CLIENT_SERVICE, "lookupService")
         runner.enableControllerService(registry)
         runner.enableControllerService(reader)
@@ -350,7 +349,7 @@ class RestLookupServiceIT {
     void setEndpoint(Integer serverPort, String endpoint) {
         // Resolve environmental part of the URL via variable registry.
         runner.setVariable("serverPort", String.valueOf(serverPort))
-        runner.setProperty(lookupService, RestLookupService.URL, endpoint)
+        runner.setProperty(lookupService, RestLookupService.URL, "http://localhost:${serverPort}" + endpoint)
         runner.enableControllerService(lookupService)
 
         runner.assertValid()


### PR DESCRIPTION
- Use PropertyValue instead of PreparedQuery to utilize Variable
Registry.
- Removed BASE_URL because Variable Registry can be used at URL

